### PR TITLE
Fix I2C address

### DIFF
--- a/src/ISM330DHCXSensor.h
+++ b/src/ISM330DHCXSensor.h
@@ -192,11 +192,11 @@ class ISM330DHCXSensor {
       }
 
       if (dev_i2c) {
-        dev_i2c->beginTransmission(((uint8_t)(((address) >> 1) & 0x7F)));
+        dev_i2c->beginTransmission(address);
         dev_i2c->write(RegisterAddr);
         dev_i2c->endTransmission(false);
 
-        dev_i2c->requestFrom(((uint8_t)(((address) >> 1) & 0x7F)), (uint8_t) NumByteToRead);
+        dev_i2c->requestFrom(address, (uint8_t) NumByteToRead);
 
         int i = 0;
         while (dev_i2c->available()) {
@@ -239,7 +239,7 @@ class ISM330DHCXSensor {
       }
 
       if (dev_i2c) {
-        dev_i2c->beginTransmission(((uint8_t)(((address) >> 1) & 0x7F)));
+        dev_i2c->beginTransmission(address);
 
         dev_i2c->write(RegisterAddr);
         for (uint16_t i = 0 ; i < NumByteToWrite ; i++) {


### PR DESCRIPTION
**Summary**

I bumped my head trying to use the ISM330DHCX over I2C with this library.

Upon debugging, it seems like the issue was with the address used in the I2C wrappers - I dont know why there is some extra logics i.e.:

```cpp
((uint8_t)(((address) >> 1) & 0x7F))
```

instead of just

```cpp
address
```

which would be what I would expect: the first argument of these I2C functions should just be the I2C address of the slave device.

**Validation**

Things now work using the ISM330DHCX over I2C.
