### PR TITLE
Hard check the ID at Init

### DIFF
--- a/src/ISM330DHCXSensor.cpp
+++ b/src/ISM330DHCXSensor.cpp
@@ -39,6 +39,21 @@ ISM330DHCXSensor::ISM330DHCXSensor(SPIClass *spi, int cs_pin, uint32_t spi_speed
  */
 ISM330DHCXStatusTypeDef ISM330DHCXSensor::Init()
 {
+  /* Check sensor ID: this checks that we can communicate with the sensor */
+
+  uint8_t Id;
+
+  /* Get the Id; note this is not enough per se depending on the I2C implementation */
+  if (ReadID(&Id) != ISM330DHCX_OK) {
+    return ISM330DHCX_ERROR;
+  }
+
+  /* Check that we actually got back the right ID; this should return an error even if
+  the I2C implementation does not complain in case of no response. */
+  if (Id != ISM330DHCX_ID) {
+    return ISM330DHCX_ERROR;
+  }
+  
   /* SW reset */
   if (ism330dhcx_reset_set(&(reg_ctx), PROPERTY_ENABLE) != ISM330DHCX_OK) {
     return ISM330DHCX_ERROR;


### PR DESCRIPTION
**Summary**

In some I2C implementations (for example, the arduino core I am using in a project), I2C communication failing to acknowledge / work can fail silently. This, combined with how the library works, means that using this library with some arduino cores may fail silently and just provide all 0s.

To mitigate this, this PR now explicitly checks the ISM330DHCX_ID during `begin`; this way, even if the communication fails silently and all 0s are returned, we will catch it and return an error status.

**Validation**

Using this PR, I now get failure if I use the wrong port / address in my arduino core, which otherwise was failing silently.

@cparata this should fix what is discussed in https://github.com/stm32duino/ISM330DHCX/pull/13#issuecomment-3767313260 .

I am not a professional embedded programmer - if you want to see changes, please either be very clear what you want me to change, or feel free to edit this PR :) .
