### PR TITLE
Add methods to read raw ACC and GYR data from FIFO

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=STM32duino ISM330DHCX
-version=2.1.1
+version=2.1.2
 author=SRA
 maintainer=stm32duino
 sentence=High-Performance 3D digital accelerometer and 3D digital gyroscope.

--- a/src/ISM330DHCXSensor.cpp
+++ b/src/ISM330DHCXSensor.cpp
@@ -2178,6 +2178,26 @@ ISM330DHCXStatusTypeDef ISM330DHCXSensor::FIFO_ACC_Get_Axes(int32_t *Acceleratio
 }
 
 /**
+ * @brief  Get the ISM330DHCX FIFO accelero single sample (16-bit data per 3 axes) raw data
+ * @param  Acceleration FIFO accelerometer raw axes reading
+ * @retval 0 in case of success, an error code otherwise
+ */
+ISM330DHCXStatusTypeDef ISM330DHCXSensor::FIFO_ACC_Get_AxesRaw(int16_t *AccelerationRaw)
+{
+  uint8_t data[6];
+
+  if (FIFO_Get_Data(data) != ISM330DHCX_OK) {
+    return ISM330DHCX_ERROR;
+  }
+
+  AccelerationRaw[0] = ((int16_t)data[1] << 8) | data[0];
+  AccelerationRaw[1] = ((int16_t)data[3] << 8) | data[2];
+  AccelerationRaw[2] = ((int16_t)data[5] << 8) | data[4];
+
+  return ISM330DHCX_OK;
+}
+
+/**
  * @brief  Get the ISM330DHCX FIFO gyro single sample (16-bit data per 3 axes) and calculate angular velocity [mDPS]
  * @param  AngularVelocity FIFO gyroscope axes [mDPS]
  * @retval 0 in case of success, an error code otherwise
@@ -2208,6 +2228,26 @@ ISM330DHCXStatusTypeDef ISM330DHCXSensor::FIFO_GYRO_Get_Axes(int32_t *AngularVel
   AngularVelocity[0] = (int32_t)angular_velocity_float[0];
   AngularVelocity[1] = (int32_t)angular_velocity_float[1];
   AngularVelocity[2] = (int32_t)angular_velocity_float[2];
+
+  return ISM330DHCX_OK;
+}
+
+/**
+ * @brief  Get the ISM330DHCX FIFO gyro single sample (16-bit data per 3 axes) raw data
+ * @param  AngularVelocity FIFO gyroscope raw axes reading
+ * @retval 0 in case of success, an error code otherwise
+ */
+ISM330DHCXStatusTypeDef ISM330DHCXSensor::FIFO_GYRO_Get_AxesRaw(int16_t *AngularVelocityRaw)
+{
+  uint8_t data[6];
+
+  if (FIFO_Get_Data(data) != ISM330DHCX_OK) {
+    return ISM330DHCX_ERROR;
+  }
+
+  AngularVelocityRaw[0] = ((int16_t)data[1] << 8) | data[0];
+  AngularVelocityRaw[1] = ((int16_t)data[3] << 8) | data[2];
+  AngularVelocityRaw[2] = ((int16_t)data[5] << 8) | data[4];
 
   return ISM330DHCX_OK;
 }

--- a/src/ISM330DHCXSensor.h
+++ b/src/ISM330DHCXSensor.h
@@ -152,7 +152,9 @@ class ISM330DHCXSensor {
     ISM330DHCXStatusTypeDef FIFO_Get_Tag(uint8_t *Tag);
     ISM330DHCXStatusTypeDef FIFO_Get_Data(uint8_t *Data);
     ISM330DHCXStatusTypeDef FIFO_ACC_Get_Axes(int32_t *Acceleration);
+    ISM330DHCXStatusTypeDef FIFO_ACC_Get_AxesRaw(int16_t *AccelerationRaw);
     ISM330DHCXStatusTypeDef FIFO_GYRO_Get_Axes(int32_t *AngularVelocity);
+    ISM330DHCXStatusTypeDef FIFO_GYRO_Get_AxesRaw(int16_t *AngularVelocityRaw);
 
     ISM330DHCXStatusTypeDef ACC_Enable_DRDY_On_INT1();
     ISM330DHCXStatusTypeDef ACC_Disable_DRDY_On_INT1();


### PR DESCRIPTION
## Pull Request template

**Summary**
Make it possible to get the raw data directly from the FIFO buffers. Similar to the `GetAxesRaw` methods that were existing for reading ACC and GYR in non FIFO settings, but for the FIFO reading setting.

**Validation**

Tested on my desk, works fine with an adapted version of the FIFO example that uses the raw readings instead.

**Closing issues**

closes #15
